### PR TITLE
updating to depend on NAudio.Core 2.0.0

### DIFF
--- a/NAudio.Vorbis/NAudio.Vorbis.csproj
+++ b/NAudio.Vorbis/NAudio.Vorbis.csproj
@@ -2,9 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>NAudio.Vorbis</RootNamespace>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>Andrew Ward</Authors>
     <Company>Andrew Ward</Company>
     <Description>NAudio support for Vorbis</Description>
@@ -14,13 +14,12 @@
     <RepositoryUrl>https://github.com/naudio/Vorbis</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>audio c# .NET sound vorbis NAudio NVorbis</PackageTags>
-    <PackageReleaseNotes>- Update to NVorbis 0.10.0
-- Update to NAudio 1.10.0
-- Added VorbisSampleProvider for more capable ISampleProvider support
-- Updated VorbisWaveReader to use VorbisSampleProvider</PackageReleaseNotes>
+    <PackageReleaseNotes>- Update to NVorbis 0.10.1
+- Update to NAudio.Core 2.0.0
+</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.2.0.1</AssemblyVersion>
-    <FileVersion>1.2.0.1</FileVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NAudio" Version="1.10.0" />
-    <PackageReference Include="NVorbis" Version="0.10.0" />
+    <PackageReference Include="NAudio.Core" Version="2.0.0" />
+    <PackageReference Include="NVorbis" Version="0.10.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Small update to depend on NAudio.Core 2.0.0 (which does mean it is netstandard2.0 only now)
Hopefully will resolve [this issue](https://github.com/naudio/NAudio/issues/739)